### PR TITLE
Utils: Remove `base16ct`

### DIFF
--- a/pocket-utils/Cargo.toml
+++ b/pocket-utils/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-base16ct = "0.1.1"
 hex = "0.4.3"
 sha2 = "0.10.2"
 thiserror = "1.0.30"

--- a/pocket-utils/src/lib.rs
+++ b/pocket-utils/src/lib.rs
@@ -18,9 +18,8 @@ pub fn address_from_public_key(public_key: &str) -> Result<String, Error> {
     };
 
     let result = Sha256::digest(decoded_public_key);
-    let mut buf = [0u8; 64];
 
-    let address = base16ct::lower::encode_str(&result, &mut buf).unwrap();
+    let address = hex::encode(result);
 
     Ok(address.to_string().chars().take(40).collect())
 }


### PR DESCRIPTION
Part of the dep cleanup—base16ct was not needed at all; `hex` is enough. Blame it on my inexperience with Rust :).